### PR TITLE
retain query string in resolved paths

### DIFF
--- a/src/service/service.ts
+++ b/src/service/service.ts
@@ -84,7 +84,11 @@ export class DaemonServer extends SockDaemonServer<
     if (target.startsWith('file://')) {
       const tsFile = findTsFile(target)
       if (tsFile) {
-        return { fileName: String(pathToFileURL(tsFile)) }
+        const queryIndex = target.indexOf('?')
+        const query = queryIndex >= 0 ? target.slice(queryIndex) : ''
+        return {
+          fileName: String(pathToFileURL(tsFile)) + query,
+        }
       }
     }
     return {}

--- a/test/service/service.ts
+++ b/test/service/service.ts
@@ -118,6 +118,31 @@ t.test('resolve', async t => {
     }),
     {}
   )
+
+  t.strictSame(
+    ds.handle({
+      id: 'id',
+      action: 'resolve',
+      url:
+        String(pathToFileURL(resolve(dir, 'foo.ts'))) + '?name=value',
+    }),
+    {
+      fileName:
+        String(pathToFileURL(resolve(dir, 'foo.ts'))) + '?name=value',
+    }
+  )
+  t.strictSame(
+    ds.handle({
+      id: 'id',
+      action: 'resolve',
+      url:
+        String(pathToFileURL(resolve(dir, 'foo.js'))) + '?name=value',
+    }),
+    {
+      fileName:
+        String(pathToFileURL(resolve(dir, 'foo.ts'))) + '?name=value',
+    }
+  )
 })
 
 t.test('compile', async t => {


### PR DESCRIPTION
I'm trying to use tsimp in conjunction with [esmock](https://github.com/iambumblehead/esmock/) and it's currently not working. esmock registers module hooks that adds some metadata to mocked import paths by adding a query string to the path, but tsimp removes this query in its `resolve` hook. Adding the query string to the resolved `.ts` path fixes the integration with esmock.