### PR TITLE
Remove unused dependency on mkdirp

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "@isaacs/cached": "^1.0.1",
         "@isaacs/catcher": "^1.0.4",
         "foreground-child": "^3.1.1",
-        "mkdirp": "^3.0.1",
         "pirates": "^4.0.6",
         "rimraf": "^5.0.5",
         "signal-exit": "^4.1.0",
@@ -3999,6 +3998,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz",
       "integrity": "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==",
+      "dev": true,
       "bin": {
         "mkdirp": "dist/cjs/src/bin.js"
       },

--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
     "@isaacs/cached": "^1.0.1",
     "@isaacs/catcher": "^1.0.4",
     "foreground-child": "^3.1.1",
-    "mkdirp": "^3.0.1",
     "pirates": "^4.0.6",
     "rimraf": "^5.0.5",
     "signal-exit": "^4.1.0",


### PR DESCRIPTION
In a7d30a99840534a7e7bd57c94cf66353e083159b, mkdirp usage was removed (sweet!), but it was left out in dependencies. It's safe to remove it now.