### PR TITLE
Write log messages from the daemon to a file

### DIFF
--- a/src/debug.ts
+++ b/src/debug.ts
@@ -1,29 +1,59 @@
 import { format } from 'util'
+import { createWriteStream } from 'node:fs'
+import { mkdirSync } from 'fs'
+
+type LogWriter = (logEntry: string) => void
+let isClient = true
+let logWriter: LogWriter = console.error
+
+const useColor = () => process.stderr.isTTY && isClient
 
 const yellow = (s: string) =>
-  process.stderr.isTTY ? `\x1b[43;30m${s}\x1b[m` : s
-const blue = (s: string) =>
-  process.stderr.isTTY ? `\x1b[44;37m${s}\x1b[m` : s
+  useColor() ? `\x1b[43;30m${s}\x1b[m` : s
+const blue = (s: string) => (useColor() ? `\x1b[44;37m${s}\x1b[m` : s)
 const red = (s: string) =>
-  process.stderr.isTTY ? `\x1b[41;30;1m${s}\x1b[m` : s
+  useColor() ? `\x1b[41;30;1m${s}\x1b[m` : s
 const magenta = (s: string) =>
-  process.stderr.isTTY ? `\x1b[45;30m${s}\x1b[m` : s
+  useColor() ? `\x1b[45;30m${s}\x1b[m` : s
 const green = (s: string) =>
-  process.stderr.isTTY ? `\x1b[42;30;2m${s}\x1b[m` : s
+  useColor() ? `\x1b[42;30;2m${s}\x1b[m` : s
 
 const level = parseInt(process.env.TSIMP_DEBUG || '0', 10)
 
+type Logger = (...args: any[]) => undefined
+
 const getLogger =
-  (name: string, color: (s: string) => string) =>
+  (name: string, color: (s: string) => string): Logger =>
   (...args: any[]) => {
     const prefix = `TSIMP ${color(name)} ${process.pid}: `
     const msg = format(...args).trim()
-    console.error(prefix + msg.split('\n').join(`\n${prefix}`))
+    logWriter(prefix + msg.split('\n').join(`\n${prefix}`))
   }
 
-export const error = getLogger('error', red)
-export const warn = level > 0 ? getLogger('warn', yellow) : () => {}
-export const debug =
-  level > 1 ? getLogger('debug', magenta) : () => {}
-export const info = level > 2 ? getLogger('info', blue) : () => {}
-export const trace = getLogger('trace', green)
+export let error: Logger
+export let warn: Logger
+export let debug: Logger
+export let info: Logger
+export let trace: Logger
+
+const initializeLoggers = () => {
+  error = getLogger('error', red)
+  warn = level > 0 ? getLogger('warn', yellow) : () => {}
+  debug = level > 1 ? getLogger('debug', magenta) : () => {}
+  info = level > 2 ? getLogger('info', blue) : () => {}
+  trace = getLogger('trace', green)
+}
+
+export const markProcessAsDaemon = () => {
+  if (isClient) {
+    isClient = false
+    mkdirSync('.tsimp/daemon', { recursive: true })
+    const writeStream = createWriteStream('.tsimp/daemon/log', {
+      flags: 'a',
+    })
+    logWriter = text => writeStream.write(`${text}\n`)
+    initializeLoggers()
+  }
+}
+
+initializeLoggers()

--- a/src/service/daemon.mts
+++ b/src/service/daemon.mts
@@ -1,4 +1,6 @@
 import { DaemonServer } from './service.js'
+import { markProcessAsDaemon } from '../debug.js'
+markProcessAsDaemon()
 const cwd = process.cwd()
 /* c8 ignore start */
 const home = (process.env.HOME ?? '').replace(/[\\\/]$/, '')


### PR DESCRIPTION
I wrote this code to help me look into #20.

The CLI has a `--log` option, but as far as I could tell, the `.tsimp/daemon/log` file wasn't being written to (though it wasn't completely empty on my system, somehow). 

This PR makes log operations performed in the daemon get written to the log file rather than `stderr`, which probably isn't hooked up to anything.

We may want to consider using a proper logging library in the future, as this code doesn't do log rotations or the like.