### PR TITLE
Attempt to fix #20

### DIFF
--- a/src/classify-module.ts
+++ b/src/classify-module.ts
@@ -21,10 +21,13 @@ const readPJType = cachedMtime(
   })
 )
 
-export const classifyModule = (fileName: string): PackageJsonType | 'json' => {
+export const classifyModule = (
+  fileName: string
+): PackageJsonType | 'json' => {
   if (fileName.endsWith('.json')) {
     return 'json'
-  } if (fileName.endsWith('.cts') || fileName.endsWith('.cjs')) {
+  }
+  if (fileName.endsWith('.cts') || fileName.endsWith('.cjs')) {
     return 'commonjs'
   } else if (fileName.endsWith('.mts') || fileName.endsWith('.mjs')) {
     return 'module'


### PR DESCRIPTION
I expected this PR to fix the issue, but as of now it does not. Any guidance is appreciated, though I can't guarantee that I'll have time to come back to this PR. If someone else has time to work on this, feel free to make a new PR that includes my changes as well.

This PR does a couple of things:
* Stops caching typescript compilation results
	* I did this because caching is currently done based on the mtime of a single file, when compilation of a given file is actually the result of not only itself, but all of the files that it imports.
	* Typescript compilation results can be cached again once `@isaacs/cached` supports caching results based on an array of files, instead of just one.
	* I did not expect this change to fix the specific issue described in #20 
* Queries the dependencies of the file being compiled using `ts.preProcessFile()`, and calls `updateFileVersion()` on each one
	* I was surprised to find that this did not fix the issue.