### PR TITLE
Fix call to getMode to include compilerOptions

### DIFF
--- a/src/service/resolve-type-reference-directive-references.ts
+++ b/src/service/resolve-type-reference-directive-references.ts
@@ -58,7 +58,8 @@ export const getResolveTypeReferenceDirectiveReferences = (
       const name = loader.nameAndMode.getName(entry)
       const mode = loader.nameAndMode.getMode(
         entry,
-        containingSourceFile
+        containingSourceFile,
+        options
       )
       const key = createModeAwareCacheKey(name, mode)
       let result = rtrdrInternalCache.get(key)


### PR DESCRIPTION
Fixes #29 

The `getMode` method of the `ResolutionNameAndModeGetter<FileReference | string, SourceFile | undefined>` interface should take a third parameter of `compilerOptions` but previously this was not passed. After https://github.com/microsoft/TypeScript/pull/58825 (released in typescript v5.6.2) this parameter is now being used. 