### PR TITLE
Document that after updating rimraf to ^6.0.0 nodejs version needs to be higher than 20

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,3 +290,6 @@ sys	0m0.022s
 ![meme comic "We need this to run faster" "rewrite it in rust" "rewrite it in zig" "use basic caching and work skipping" guy gets thrown out window](https://github.com/tapjs/tsimp/raw/main/faster.jpg)
 
 Basic caching and work skipping.
+
+## Support for older NodeJS versions
+Support for Node 18.X was dropped in version `2.0.12`. Dowgrade to `2.0.11` if you need to use older Node.

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "fail-skip": true
   },
   "engines": {
-    "node": "16 >=16.17.0 || 18 >= 18.6.0 || >=20"
+    "node": ">=20"
   },
   "module": "./dist/esm/index.js"
 }


### PR DESCRIPTION
Hey,

After I upgraded `tsimp` to version 2.0.12 I got following error message:
```sh
$ yarn install
yarn install v1.22.22
[1/5] 🔍  Validating package.json...
[2/5] 🔍  Resolving packages...
[3/5] 🚚  Fetching packages...
error rimraf@6.0.1: The engine "node" is incompatible with this module. Expected version "20 || >=22". Got "18.20.4"
```

I'm still using Node 18 for now and wanted to make it clearer that 2.0.12 drops support for earlier node versions.